### PR TITLE
Fix: Include subtask directory in tar/untar

### DIFF
--- a/automech/cli.py
+++ b/automech/cli.py
@@ -131,18 +131,18 @@ def subtasks_setup_(
     help="A comma-separated list of statuses to run or re-run",
 )
 @click.option(
-    "-z",
-    "--archive-save",
+    "-t",
+    "--tar",
     default=False,
     is_flag=True,
-    help="Archive the save filesystem after running?",
+    help="Tar the subtask data and save filesystem after running?",
 )
 def subtasks_run_(
     nodes: tuple[str, ...],
     path: str = subtasks.SUBTASK_DIR,
     activation_hook: str | None = None,
     statuses: str = f"{Status.TBD.value}",
-    archive_save: bool = False,
+    tar: bool = False,
 ):
     """Run subtasks in parallel on an Ad Hoc SSH Cluster
 
@@ -163,7 +163,7 @@ def subtasks_run_(
         nodes=nodes,
         activation_hook=activation_hook,
         statuses=list(map(Status, statuses.split(","))),
-        archive_save=archive_save,
+        tar=tar,
     )
 
 

--- a/automech/subtasks/__init__.py
+++ b/automech/subtasks/__init__.py
@@ -2,13 +2,13 @@
 
 from ._0setup import SUBTASK_DIR, setup
 from ._1status import status
-from ._2run import run, tar_save_directory, untar_save_directory
+from ._2run import run, tar_subtask_data, untar_subtask_data
 
 __all__ = [
     "setup",
     "SUBTASK_DIR",
     "status",
     "run",
-    "tar_save_directory",
-    "untar_save_directory",
+    "tar_subtask_data",
+    "untar_subtask_data",
 ]


### PR DESCRIPTION
This is convenient for getting the save directory path from subtasks/info.yaml, but we will also be able to use it for checking the log files from the electronic structure runs.